### PR TITLE
Speed up the `find_zip` method + support for exact queries and limits

### DIFF
--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -1,4 +1,4 @@
-from settings import db_location
+from .settings import db_location
 try:
     import sqlite3
 except ImportError:
@@ -23,7 +23,7 @@ class ConnectionManager(object):
         # then just give up...
             try:
                 conn = sqlite3.connect(db_location)
-            except sqlite3.OperationalError, x:
+            except sqlite3.OperationalError:
                 retry_count += 1
                 time.sleep(0.001)
 

--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -89,16 +89,16 @@ class ZipCodeDatabase(object):
             q = "SELECT * FROM ZipCodes"
         elif state and city:
             q = "SELECT * FROM ZipCodes WHERE city%(cmp)s? AND state%(cmp)s?" % {'cmp': cmp}
-
-        if city is None:
-            q = "SELECT * FROM ZipCodes WHERE state%s?" % cmp
         else:
-            city = city.upper()
+            if city is None:
+                q = "SELECT * FROM ZipCodes WHERE state%s?" % cmp
+            else:
+                city = city.upper()
 
-        if state is None:
-            q = "SELECT * FROM ZipCodes WHERE city%s?" % cmp
-        else:
-            state = state.upper()
+            if state is None:
+                q = "SELECT * FROM ZipCodes WHERE city%s?" % cmp
+            else:
+                state = state.upper()
 
         if limit is not None:
             q+= ' LIMIT 0, %d' % limit

--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -3,7 +3,6 @@ try:
     import sqlite3
 except ImportError:
     from pysqlite2 import dbapi2 as sqlite3
-import math
 import time
 
 class ConnectionManager(object):
@@ -85,9 +84,9 @@ class ZipCodeDatabase(object):
 
     def find_zip(self, city=None, state=None, limit=None, exact=False):
         cmp = ' LIKE ' if not exact else '='
-        if not city and not state:
+        if city is None and state is None:
             q = "SELECT * FROM ZipCodes"
-        elif state and city:
+        elif state is not None and city is not None:
             q = "SELECT * FROM ZipCodes WHERE city%(cmp)s? AND state%(cmp)s?" % {'cmp': cmp}
         else:
             if city is None:
@@ -103,7 +102,7 @@ class ZipCodeDatabase(object):
         if limit is not None:
             q+= ' LIMIT 0, %d' % limit
 
-        args = [arg for arg in [city, state] if arg]
+        args = [arg for arg in [city, state] if arg is not None]
         return format_result(self.conn_manager.query(q, args))
 
     def get(self, zip):


### PR DESCRIPTION
Master branch:

```
In [3]: %timeit pyzipcode.ZipCodeDatabase().find_zip(state='CA')
10 loops, best of 3: 32 ms per loop
```

This PR:

```
In [2]: %timeit pyzipcode.ZipCodeDatabase().find_zip(state='CA')
10 loops, best of 3: 25.6 ms per loop

In [3]: %timeit pyzipcode.ZipCodeDatabase().find_zip(state='CA', exact=True)
100 loops, best of 3: 14.3 ms per loop

In [4]: %timeit pyzipcode.ZipCodeDatabase().find_zip(state='CA', exact=True, limit=1)
1000 loops, best of 3: 273 us per loop
```

The code is a bit less readable, but the performance gains are significant, especially if you don't need all the zip codes for a given city/state (hence the limit) and you're searching for an exact match.
