### PR TITLE
Fix unit tests on python 2.6 and 2.7.

### DIFF
--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -16,7 +16,7 @@ class ConnectionManager(object):
         conn = sqlite3.connect(db_location)
         conn.close()
             
-    def query(self, sql, args):
+    def query(self, sql, args=tuple()):
         conn = None
         retry_count = 0
         while not conn and retry_count <= 10:


### PR DESCRIPTION
Unit tests seem totally broken on python 2.6 and 2.7.  Same issue needs to be fixed for python 3 compatibility.