### PR TITLE
Python 3 compatibility (fixes issue #7)

### DIFF
--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -1,4 +1,4 @@
-from settings import db_location
+from .settings import db_location
 try:
     import sqlite3
 except ImportError:
@@ -24,7 +24,7 @@ class ConnectionManager(object):
         # then just give up...
             try:
                 conn = sqlite3.connect(db_location)
-            except sqlite3.OperationalError, x:
+            except sqlite3.OperationalError as x:
                 retry_count += 1
                 time.sleep(0.001)
         

--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -16,7 +16,7 @@ class ConnectionManager(object):
         conn = sqlite3.connect(db_location)
         conn.close()
             
-    def query(self, sql, args):
+    def query(self, sql, args=tuple()):
         conn = None
         retry_count = 0
         while not conn and retry_count <= 10:

--- a/pyzipcode/import.py
+++ b/pyzipcode/import.py
@@ -1,5 +1,7 @@
-
-from pysqlite2 import dbapi2 as sqlite3
+try:
+    import sqlite3
+except ImportError:
+    from pysqlite2 import dbapi2 as sqlite3
 import os
 import csv
 try:

--- a/pyzipcode/tests.py
+++ b/pyzipcode/tests.py
@@ -10,9 +10,9 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_retrieves_zip_code_information(self):
         zip = self.db['54115']
-        self.assertEquals(zip.zip, '54115')
-        self.assertEquals(zip.city, "De Pere")
-        self.assertEquals(zip.state, "WI")
+        self.assertEqual(zip.zip, '54115')
+        self.assertEqual(zip.city, "De Pere")
+        self.assertEqual(zip.state, "WI")
         
     def test_correct_longitude_value(self):
         zip = self.db[54115]
@@ -24,11 +24,11 @@ class TestSequenceFunctions(unittest.TestCase):
         
     def test_correct_timezone(self):
         zip = self.db[54115]
-        self.assertEquals(zip.timezone, -6)
+        self.assertEqual(zip.timezone, -6)
         
     def test_correct_dst(self):
         zip = self.db[54115]
-        self.assertEquals(zip.dst, 1)
+        self.assertEqual(zip.dst, 1)
         
     def test_radius(self):
         zips = self.db.get_zipcodes_around_radius('54115', 30)
@@ -36,7 +36,7 @@ class TestSequenceFunctions(unittest.TestCase):
         
     def test_find_zip_by_city(self):
         zip = self.db.find_zip(city="De Pere")[0]
-        self.assertEquals('54115', zip.zip)
+        self.assertEqual('54115', zip.zip)
         
     def test_find_zip_by_city_with_multiple_zips(self):
         zips = self.db.find_zip(city="Green Bay")


### PR DESCRIPTION
This small change makes pyzipcode independent from pysqlite, which is the only dependency that is not Python 3 friendly. Fixes #7 